### PR TITLE
FLOW-8791: enable etags again (using browsers CacheStorage)

### DIFF
--- a/src/http/cache/cache.ts
+++ b/src/http/cache/cache.ts
@@ -1,5 +1,4 @@
-
-const cacheName = "ff-api-cache"
+const cacheName = 'ff-api-cache';
 
 export const ApiCache = {
     async get(url: string): Promise<CacheValue | undefined> {
@@ -14,37 +13,37 @@ export const ApiCache = {
     },
 
     async set(url: string, body: any, headers: HeaderObject) {
-        body = isStreamContent(headers) ? body : JSON.stringify(body)
+        body = isStreamContent(headers) ? body : JSON.stringify(body);
         try {
-            return (await apiCache()).put(url, new Response(body, { headers }))
-        } catch(e) {
-            console.error("error writing to api-cache for: " + url + ". Maybe cache is full, resetting cache and trying again.", e)
-            await this.reset()
-            return (await apiCache()).put(url, new Response(body, { headers }))
-        }  
+            return (await apiCache()).put(url, new Response(body, { headers }));
+        } catch (error) {
+            console.error(`error writing to api-cache for: ${url}. Maybe cache is full, resetting cache and trying again.`, error);
+            await this.reset();
+            return (await apiCache()).put(url, new Response(body, { headers }));
+        }
     },
 
     async reset() {
-        return caches.delete(cacheName)
-    }
-}
+        return caches.delete(cacheName);
+    },
+};
 
 async function apiCache() {
-    return await caches.open(cacheName)
+    return await caches.open(cacheName);
 }
 
 function getHeadersObject(headers: Headers) {
     let result = {} as HeaderObject;
-    headers.forEach((value, key) => result[key] = value)
+    headers.forEach((value, key) => (result[key] = value));
     return result;
 }
 
 function isStreamContent(headers: HeaderObject) {
-    return headers["content-type"]?.includes("-stream") // e.g. application/octet-stream
+    return headers['content-type']?.includes('-stream'); // e.g. application/octet-stream
 }
 
-export type HeaderObject = {[key: string]: string}
+export type HeaderObject = { [key: string]: string };
 export type CacheValue = {
     body: any;
     headers: HeaderObject;
-}
+};

--- a/src/http/cache/cache.ts
+++ b/src/http/cache/cache.ts
@@ -4,7 +4,9 @@ const cacheName = "ff-api-cache"
 export const ApiCache = {
     async get(url: string): Promise<CacheValue | undefined> {
         const item = await (await apiCache()).match(url);
-        if (!item) return;
+        if (!item) {
+            return;
+        }
 
         const headers = getHeadersObject(item.headers);
         const body = isStreamContent(headers) ? await item.arrayBuffer() : await item.json();
@@ -33,12 +35,7 @@ async function apiCache() {
 
 function getHeadersObject(headers: Headers) {
     let result = {} as HeaderObject;
-    const keys = (headers as any).keys();
-    let header = keys.next();
-    while (header.value) {
-        result[header.value] = headers.get(header.value) || "";
-        header = keys.next();
-    }
+    headers.forEach((value, key) => result[key] = value)
     return result;
 }
 

--- a/src/http/cache/index.ts
+++ b/src/http/cache/index.ts
@@ -1,73 +1,44 @@
-import { Cache } from './cache';
+import { ApiCache  } from './cache';
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 
-function isCacheableMethod(config: AxiosRequestConfig) {
-    return ~['GET', 'HEAD'].indexOf((config.method as string).toUpperCase());
-}
-
-function getUUIDByAxiosConfig(config: AxiosRequestConfig): string {
-    return config.url as string;
-}
-
-// commented because of https://flowfact.atlassian.net/browse/FLOW-9170
-// function getHeaderCaseInsensitive(headerName: string, headers = {}) {
-//     const headerKeys = Object.keys(headers);
-//     const key = headerKeys.find((value) => value.toLowerCase() === headerName);
-//     if (!key) {
-//         return undefined;
-//     }
-//
-//     return headers[key];
-// }
-
-function getCacheByAxiosConfig(config: AxiosRequestConfig) {
-    return Cache.get(getUUIDByAxiosConfig(config));
-}
-
-function requestInterceptor(config: AxiosRequestConfig) {
+async function requestInterceptor(config: AxiosRequestConfig) {
     if (isCacheableMethod(config)) {
-        const uuid = getUUIDByAxiosConfig(config);
-        const lastCachedResult = Cache.get(uuid);
-        if (lastCachedResult) {
-            config.headers = { ...config.headers, 'If-None-Match': lastCachedResult.etag };
+        const cachedEtag = (await getCachedItem(config))?.headers?.etag;
+        if (cachedEtag) {
+            config.headers = { ...config.headers, 'If-None-Match': cachedEtag };
         }
     }
     return config;
 }
 
-function responseInterceptor(response: AxiosResponse) {
-    // commented because of https://flowfact.atlassian.net/browse/FLOW-9170
-    // if (isCacheableMethod(response.config)) {
-    //     const responseETAG = getHeaderCaseInsensitive('etag', response.headers);
-    //     if (responseETAG) {
-    //         Cache.set(getUUIDByAxiosConfig(response.config), responseETAG, response.data);
-    //     }
-    // }
+async function responseInterceptor(response: AxiosResponse) {
+    if (isCacheableMethod(response.config) && response.headers?.etag) {
+        ApiCache.set(response.config.url!, response.data, response.headers);
+    }
     return response;
 }
 
-function responseErrorInterceptor(error: AxiosError) {
+async function responseErrorInterceptor(error: AxiosError) {
     if (error.response && error.response.status === 304) {
-        const getCachedResult = getCacheByAxiosConfig(error.response.config);
-        if (!getCachedResult) {
-            return Promise.reject(error);
+        const cachedItem = await getCachedItem(error.response.config);
+        if (cachedItem) {
+            return Promise.resolve({ ...error.response, status: 200, data: cachedItem.body, headers: cachedItem.headers });
         }
-        const newResponse = error.response;
-        newResponse.status = 200;
-        newResponse.data = getCachedResult.value;
-        return Promise.resolve(newResponse);
     }
     return Promise.reject(error);
 }
 
-export function resetCache() {
-    Cache.reset();
+function isCacheableMethod(config: AxiosRequestConfig) {
+    return ~['GET', 'HEAD'].indexOf((config.method as string).toUpperCase());
+}
+
+function getCachedItem(config: AxiosRequestConfig) {
+    return ApiCache.get(config.url!);
 }
 
 export default function axiosETAGCache(config?: AxiosRequestConfig) {
     const instance = axios.create(config);
     instance.interceptors.request.use(requestInterceptor);
     instance.interceptors.response.use(responseInterceptor, responseErrorInterceptor);
-
     return instance;
 }

--- a/src/http/cache/index.ts
+++ b/src/http/cache/index.ts
@@ -1,4 +1,4 @@
-import { ApiCache  } from './cache';
+import { ApiCache } from './cache';
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 async function requestInterceptor(config: AxiosRequestConfig) {
@@ -38,7 +38,10 @@ function getCachedItem(config: AxiosRequestConfig) {
 
 export default function axiosETAGCache(config?: AxiosRequestConfig) {
     const instance = axios.create(config);
-    instance.interceptors.request.use(requestInterceptor);
-    instance.interceptors.response.use(responseInterceptor, responseErrorInterceptor);
+    const cacheStorageAvailable = typeof caches !== 'undefined';
+    if (cacheStorageAvailable) {
+        instance.interceptors.request.use(requestInterceptor);
+        instance.interceptors.response.use(responseInterceptor, responseErrorInterceptor);
+    }
     return instance;
 }

--- a/src/http/cache/index.ts
+++ b/src/http/cache/index.ts
@@ -11,7 +11,7 @@ async function requestInterceptor(config: AxiosRequestConfig) {
     return config;
 }
 
-async function responseInterceptor(response: AxiosResponse) {
+function responseInterceptor(response: AxiosResponse) {
     if (isCacheableMethod(response.config) && response.headers?.etag) {
         ApiCache.set(response.config.url!, response.data, response.headers);
     }


### PR DESCRIPTION
I documented my research and problems with the old implementation here: https://flowfact.atlassian.net/browse/FLOW-8791
Deployed branch to see it in action: http://d3b92y4iaiunn.cloudfront.net/