### PR TITLE
FLOW-9500 rename to match backend naming

### DIFF
--- a/src/service/DocumentTemplateService/DocumentTemplateService.Types.ts
+++ b/src/service/DocumentTemplateService/DocumentTemplateService.Types.ts
@@ -13,7 +13,7 @@ export interface BaseTemplate {
     captions: Captions;
     fileType: string;
     neededPlaceholders: NeededPlaceholder[];
-    type?: 'WORD' | 'HTML';
+    templateType?: 'WORD' | 'HTML';
 }
 
 export interface ReadTemplate extends BaseTemplate {
@@ -26,7 +26,7 @@ export interface BaseCategory {
     parentName: string | null;
     name: string;
     captions: Captions;
-    type?: 'WORD' | 'HTML';
+    templateType?: 'WORD' | 'HTML';
 }
 
 export interface ReadCategory extends BaseCategory {


### PR DESCRIPTION
Just renaming type to templateType in BaseCategory and BaseTemplate. This is requried to match naming in backend.