### PR TITLE
fix FLOW-11458: fix wrong name of query parameter

### DIFF
--- a/src/service/PortalManagementService/PortalController.ts
+++ b/src/service/PortalManagementService/PortalController.ts
@@ -19,7 +19,7 @@ export class PortalController extends APIClient {
         return await this.invokeApiWithErrorHandling<Portal[]>('/portals', 'GET', undefined, {
             queryParams: {
                 ignoreInactivePortals,
-                portalType,
+                type: portalType,
             },
         });
     }


### PR DESCRIPTION
Query parameter had wrong name. It should not be portalType but just type. 