### PR TITLE
FLOW-14349 Add mailchimp webhook callbackUrl param and set default value

### DIFF
--- a/src/service/MailchimpSyncIntegrationService/MailchimpController.ts
+++ b/src/service/MailchimpSyncIntegrationService/MailchimpController.ts
@@ -1,7 +1,7 @@
 import { APIClient, APIMapping } from '../../http';
 import { MailchimpServiceTypes } from './MailchimpService.Types';
 import { PagedResponse } from '@flowfact/types';
-import {EnvironmentManagementInstance} from "../../util/EnvironmentManagement";
+import { EnvironmentManagementInstance } from '../../util/EnvironmentManagement';
 
 export class MailchimpController extends APIClient {
     constructor() {

--- a/src/service/MailchimpSyncIntegrationService/MailchimpController.ts
+++ b/src/service/MailchimpSyncIntegrationService/MailchimpController.ts
@@ -1,6 +1,7 @@
 import { APIClient, APIMapping } from '../../http';
 import { MailchimpServiceTypes } from './MailchimpService.Types';
 import { PagedResponse } from '@flowfact/types';
+import {EnvironmentManagementInstance} from "../../util/EnvironmentManagement";
 
 export class MailchimpController extends APIClient {
     constructor() {
@@ -53,7 +54,10 @@ export class MailchimpController extends APIClient {
      * @param settings
      */
     async saveSettings(settings: MailchimpServiceTypes.Settings) {
-        return this.invokeApiWithErrorHandling<MailchimpServiceTypes.Settings>(`/settings`, 'POST', settings);
+        return this.invokeApiWithErrorHandling<MailchimpServiceTypes.Settings>(`/settings`, 'POST', {
+            ...settings,
+            callbackUrl: settings.callbackUrl ?? EnvironmentManagementInstance.getBaseUrl(),
+        });
     }
 
     /**
@@ -61,7 +65,10 @@ export class MailchimpController extends APIClient {
      * @param settings
      */
     async updateSettings(settings: MailchimpServiceTypes.Settings) {
-        return this.invokeApiWithErrorHandling<MailchimpServiceTypes.Settings>(`/settings`, 'PUT', settings);
+        return this.invokeApiWithErrorHandling<MailchimpServiceTypes.Settings>(`/settings`, 'PUT', {
+            ...settings,
+            callbackUrl: settings.callbackUrl ?? EnvironmentManagementInstance.getBaseUrl(),
+        });
     }
 
     /**

--- a/src/service/MailchimpSyncIntegrationService/MailchimpService.Types.ts
+++ b/src/service/MailchimpSyncIntegrationService/MailchimpService.Types.ts
@@ -11,6 +11,7 @@ export namespace MailchimpServiceTypes {
     export interface Settings {
         syncDirection: SyncDirection;
         listIds: string[];
+        callbackUrl?: string;
     }
 
     export interface SyncStatus {


### PR DESCRIPTION
## Summary
Mailchimp setting interface has a new param for callback url to pass for Mailchimp campaigns webhook. Default value is provided based on `EnvironmentManagement`.

<br />

## Checklist
___
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (ESLint)

<br />

## Links
___
- Jira: https://flowfact.atlassian.net/browse/FLOW-14349

<br />

Thanks so much for your PR, your contribution is appreciated! ❤️
