### PR TITLE
feat FLOW-17174: estate PublishResponse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowfact/api-services",
-    "version": "61.0.0-SNAPSHOT",
+    "version": "62.0.0-SNAPSHOT",
     "description": "middleware of FLOWFACT to interact between frontend and backend",
     "main": "build/index.js",
     "module": "build/es/index.js",

--- a/src/service/PortalManagementService/PortalManagementService.Types.ts
+++ b/src/service/PortalManagementService/PortalManagementService.Types.ts
@@ -43,6 +43,34 @@ export namespace PortalManagementTypes {
         portalType?: PortalType;
     }
 
+    export interface PublishResponse {
+        companyId: string;
+        userId: string;
+        errors: PublishResponseEntry[];
+        warnings: PublishResponseEntry[];
+        successFullyTransfered: PublishResponseEntry[];
+    }
+
+    export interface PublishResponseEntry {
+        detailedMessages: DetailedMessage[];
+        entityId: string;
+        externalId: string | null;
+        messages: string[];
+        portalId: string | null;
+        publishChannels: PublishChannel[];
+        schema: string | null;
+        schemaId: string | null;
+        showAddress: boolean | null;
+        targetStatus: PortalEstateStatusType | null;
+        timestamp: number | null;
+        usedIdForPortal: string | null;
+    }
+
+    export interface DetailedMessage {
+        originalMessage: string;
+        validationError: string | null;
+    }
+
     export interface PublishRequestEntry {
         entityId: string;
         externalId?: string;

--- a/src/service/PortalManagementService/PortalManagementService.Types.ts
+++ b/src/service/PortalManagementService/PortalManagementService.Types.ts
@@ -68,7 +68,12 @@ export namespace PortalManagementTypes {
 
     export interface DetailedMessage {
         originalMessage: string;
-        validationError: string | null;
+        validationError: ValidationError | null;
+    }
+
+    export interface ValidationError {
+        translatedMessage: string;
+        type: string
     }
 
     export interface PublishRequestEntry {

--- a/src/service/PortalManagementService/PublishController.ts
+++ b/src/service/PortalManagementService/PublishController.ts
@@ -14,7 +14,7 @@ export class PublishController extends APIClient {
      * @param publishRequest
      * */
     async publishEstates(publishRequest: PublishRequest) {
-        return await this.invokeApiWithErrorHandling<PublishRequest>('/publish', 'POST', publishRequest);
+        return await this.invokeApiWithErrorHandling<void>('/publish', 'POST', publishRequest);
     }
 
     /**

--- a/src/service/PortalManagementService/PublishController.ts
+++ b/src/service/PortalManagementService/PublishController.ts
@@ -13,6 +13,7 @@ export class PublishController extends APIClient {
     /**
      * Allows publishing(ONLINE/OFFLINE) estates to portal
      * @param publishRequest
+     * @return {void} when kafka is enabled AND portal type is not Wordpress. Otherwise return {PublishResponse}
      * */
     async publishEstates(publishRequest: PublishRequest) {
         return await this.invokeApiWithErrorHandling<PublishResponse | void>('/publish', 'POST', publishRequest);

--- a/src/service/PortalManagementService/PublishController.ts
+++ b/src/service/PortalManagementService/PublishController.ts
@@ -3,6 +3,7 @@ import { PortalManagementTypes } from './PortalManagementService.Types';
 import PublishRequest = PortalManagementTypes.PublishRequest;
 import BulkPublishRequest = PortalManagementTypes.BulkPublishRequest;
 import PublishBulkResponse = PortalManagementTypes.PublishBulkResponse;
+import PublishResponse = PortalManagementTypes.PublishResponse;
 
 export class PublishController extends APIClient {
     constructor() {
@@ -14,7 +15,7 @@ export class PublishController extends APIClient {
      * @param publishRequest
      * */
     async publishEstates(publishRequest: PublishRequest) {
-        return await this.invokeApiWithErrorHandling<void>('/publish', 'POST', publishRequest);
+        return await this.invokeApiWithErrorHandling<PublishResponse | void>('/publish', 'POST', publishRequest);
     }
 
     /**


### PR DESCRIPTION
## Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Added `PublishResponse` to `PortalManagementService.Types`. It's missing and due to this fact we have some ESLint errors&warnings in `platform-apps`
- Changed return type of the publish request to `PublishResponse | void` because it actually does not return anything in some cases and in some it returns `PublishResponse`

![image](https://user-images.githubusercontent.com/32751479/140167672-d3ce8678-a3c8-417a-98ea-904b799922a9.png)
![image](https://user-images.githubusercontent.com/32751479/140167713-a36061e5-7835-44f7-8a46-cc4222cd10cc.png)
![image](https://user-images.githubusercontent.com/32751479/140178792-209767c5-b156-4fff-985f-df133426467d.png)
![image](https://user-images.githubusercontent.com/32751479/140179441-d762d45d-1646-4738-9710-87c4f248af58.png)

## Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings (ESLint)

## Links

-   FLOW-17174

Thanks so much for your PR, your contribution is appreciated! ❤️
