### PR TITLE
FLOW-18282 Activity report v2 endpoint for getting email content

### DIFF
--- a/src/service/ActivityReportService/ActivityReportV2Controller.ts
+++ b/src/service/ActivityReportService/ActivityReportV2Controller.ts
@@ -48,7 +48,7 @@ export class ActivityReportV2Controller extends APIClient {
      * @param links array of links to activity reports
      * @param estateId entity id of the estate object
      */
-    async getEmailContent(links: ActivityReportLinkType[], estateId: string): Promise<ApiResponse<LambdaServiceResponse>> {
+    async fetchEmailContent(links: ActivityReportLinkType[], estateId: string): Promise<ApiResponse<LambdaServiceResponse>> {
         const authenticationToken = await this.getAuthenticationToken();
         const requestBody: ActivityReportRequestBody = {
             cognitoToken: authenticationToken,

--- a/src/service/ActivityReportService/ActivityReportV2Controller.ts
+++ b/src/service/ActivityReportService/ActivityReportV2Controller.ts
@@ -44,6 +44,24 @@ export class ActivityReportV2Controller extends APIClient {
     }
 
     /**
+     * Prepares the body of the activity report email with all placeholders already filled by Lambda service.
+     * @param links array of links to activity reports
+     * @param estateId entity id of the estate object
+     */
+    async getEmailContent(links: ActivityReportLinkType[], estateId: string): Promise<ApiResponse<LambdaServiceResponse>> {
+        const authenticationToken = await this.getAuthenticationToken();
+        const requestBody: ActivityReportRequestBody = {
+            cognitoToken: authenticationToken,
+            entityId: estateId,
+            method: 'getEmailContent',
+            links,
+        };
+        return await this.invokeApiWithErrorHandling<LambdaServiceResponse>('/activity-report2-lambda', 'POST', requestBody, {
+            headers: { 'Content-Type': 'application/json' },
+        });
+    }
+
+    /**
      * Generate a URL to get a preview of activity report, without creating a context file
      * @param activityReportId entity id of the activity report instance
      */

--- a/src/service/ActivityReportService/ActivityReportV2Controller.ts
+++ b/src/service/ActivityReportService/ActivityReportV2Controller.ts
@@ -45,10 +45,10 @@ export class ActivityReportV2Controller extends APIClient {
 
     /**
      * Prepares the body of the activity report email with all placeholders already filled by Lambda service.
-     * @param links array of links to activity reports
      * @param estateId entity id of the estate object
+     * @param links array of links to activity reports
      */
-    async fetchEmailContent(links: ActivityReportLinkType[], estateId: string): Promise<ApiResponse<LambdaServiceResponse>> {
+    async fetchEmailContent(estateId: string, links: ActivityReportLinkType[]) {
         const authenticationToken = await this.getAuthenticationToken();
         const requestBody: ActivityReportRequestBody = {
             cognitoToken: authenticationToken,


### PR DESCRIPTION
## Summary

New endpoint for getting email template of activity report. This endpoint uses the PlaceholderService to fill all placeholders in the templates on backend (different templates depending on company market). 
Previously used endpoint (`prepareEmailBody`) just returned the html with placeholders and the logic of filling data was executed on frontend. I'm adding a new endpoint in order not to break development and production, as the endpoint requires additional estateId parameter. When it is tested and frontend changes are merged I'll remove the old endpoint .

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings (ESLint)

## Links

-   Jira: [FLOW-18282](https://flowfact.atlassian.net/browse/FLOW-18282)

Thanks so much for your PR, your contribution is appreciated! ❤️
