### PR TITLE
feat CXGFF-394 - use APIService instead of LambdaAPIService, cause th…

### DIFF
--- a/src/http/APIMapping.ts
+++ b/src/http/APIMapping.ts
@@ -120,7 +120,7 @@ const APIMapping = {
     calendarSyncService: new APIService('calendar-sync-service'),
     featureToggleService: new APIService('feature-toggle-service'),
     swissLeadService: new APIService('swiss-lead-service'),
-    is24EstateStatisticsLambdaService: new LambdaAPIService('is24-estate-statistics-lambda'),
+    is24EstateStatisticsLambdaService: new APIService('is24-estate-statistics-lambda'),
 };
 
 export default APIMapping;

--- a/src/http/APIMapping.ts
+++ b/src/http/APIMapping.ts
@@ -8,16 +8,11 @@ export class APIService {
     }
 }
 
-export enum LambdaAPIVersion {
-    V1 = 'V1',
-    V2 = 'V2'
-}
-
+// deprecated - useable only for Lambdas created with the old scaffold. For new Lambdas just use APIService.
 export class LambdaAPIService extends APIService {
-    constructor(serviceName: string, private readonly forceUrl: string | undefined = undefined, readonly apiVersion: LambdaAPIVersion = LambdaAPIVersion.V2) {
+    constructor(serviceName: string, private readonly forceUrl: string | undefined = undefined) {
         super(serviceName);
         this.forceUrl = forceUrl;
-        this.apiVersion = apiVersion;
     }
 
     get url() {
@@ -50,8 +45,8 @@ const APIMapping = {
     customerLegitimationArchiveService: new APIService('customer-legitimation-archive-service'),
     dynamicLayoutService: new APIService('dynamic-layout-service'),
     emailService: new APIService('email-service'),
-    entitlementService: new LambdaAPIService('entitlement-lambda', undefined, LambdaAPIVersion.V1),
-    interactiveExposeV2LambdaService: new LambdaAPIService('iex2-expose-lambda', undefined, LambdaAPIVersion.V1),
+    entitlementService: new LambdaAPIService('entitlement-lambda'),
+    interactiveExposeV2LambdaService: new LambdaAPIService('iex2-expose-lambda'),
     interactiveExposeV2S3Service: new S3APIService('iex2-expose'),
     // entitlementService: new LambdaAPIService('entitlement-lambda', 'http://localhost:3001/offline'), // for local offline usage
     fieldCalculationService: new APIService('entity-field-calculation-service'),
@@ -126,7 +121,7 @@ const APIMapping = {
     calendarSyncService: new APIService('calendar-sync-service'),
     featureToggleService: new APIService('feature-toggle-service'),
     swissLeadService: new APIService('swiss-lead-service'),
-    is24EstateStatisticsLambdaService: new LambdaAPIService('is24-estate-statistics-lambda'),
+    is24EstateStatisticsLambdaService: new APIService('is24-estate-statistics-lambda'),
 };
 
 export default APIMapping;

--- a/src/http/APIMapping.ts
+++ b/src/http/APIMapping.ts
@@ -53,7 +53,7 @@ const APIMapping = {
     entitlementService: new LambdaAPIService('entitlement-lambda', undefined, LambdaAPIVersion.V1),
     interactiveExposeV2LambdaService: new LambdaAPIService('iex2-expose-lambda', undefined, LambdaAPIVersion.V1),
     interactiveExposeV2S3Service: new S3APIService('iex2-expose'),
-    // entitlementService: new LambdaAPIService('entitlement-lambda', 'http://localhost:3001/offline', LambdaAPIVersion.V1), // for local offline usage
+    // entitlementService: new LambdaAPIService('entitlement-lambda', 'http://localhost:3001/offline'), // for local offline usage
     fieldCalculationService: new APIService('entity-field-calculation-service'),
     entityService: new APIService('entity-service'),
     entityShareService: new APIService('entity-share-service'),

--- a/src/http/APIMapping.ts
+++ b/src/http/APIMapping.ts
@@ -8,10 +8,16 @@ export class APIService {
     }
 }
 
+export enum LambdaAPIVersion {
+    V1 = 'V1',
+    V2 = 'V2'
+}
+
 export class LambdaAPIService extends APIService {
-    constructor(serviceName: string, private readonly forceUrl: string | undefined = undefined) {
+    constructor(serviceName: string, private readonly forceUrl: string | undefined = undefined, readonly apiVersion: LambdaAPIVersion = LambdaAPIVersion.V2) {
         super(serviceName);
         this.forceUrl = forceUrl;
+        this.apiVersion = apiVersion;
     }
 
     get url() {
@@ -44,10 +50,10 @@ const APIMapping = {
     customerLegitimationArchiveService: new APIService('customer-legitimation-archive-service'),
     dynamicLayoutService: new APIService('dynamic-layout-service'),
     emailService: new APIService('email-service'),
-    entitlementService: new LambdaAPIService('entitlement-lambda'),
-    interactiveExposeV2LambdaService: new LambdaAPIService('iex2-expose-lambda'),
+    entitlementService: new LambdaAPIService('entitlement-lambda', undefined, LambdaAPIVersion.V1),
+    interactiveExposeV2LambdaService: new LambdaAPIService('iex2-expose-lambda', undefined, LambdaAPIVersion.V1),
     interactiveExposeV2S3Service: new S3APIService('iex2-expose'),
-    // entitlementService: new LambdaAPIService('entitlement-lambda', 'http://localhost:3001/offline'), // for local offline usage
+    // entitlementService: new LambdaAPIService('entitlement-lambda', 'http://localhost:3001/offline', LambdaAPIVersion.V1), // for local offline usage
     fieldCalculationService: new APIService('entity-field-calculation-service'),
     entityService: new APIService('entity-service'),
     entityShareService: new APIService('entity-share-service'),
@@ -120,7 +126,7 @@ const APIMapping = {
     calendarSyncService: new APIService('calendar-sync-service'),
     featureToggleService: new APIService('feature-toggle-service'),
     swissLeadService: new APIService('swiss-lead-service'),
-    is24EstateStatisticsLambdaService: new APIService('is24-estate-statistics-lambda'),
+    is24EstateStatisticsLambdaService: new LambdaAPIService('is24-estate-statistics-lambda'),
 };
 
 export default APIMapping;

--- a/src/util/EnvironmentManagement.ts
+++ b/src/util/EnvironmentManagement.ts
@@ -1,6 +1,6 @@
 import * as isNode from 'detect-node';
 import { region } from '../authentication/Authentication';
-import {LambdaAPIService, LambdaAPIVersion, S3APIService} from '../http/APIMapping';
+import { LambdaAPIService, S3APIService } from '../http/APIMapping';
 
 enum StageTypes {
     PRODUCTION = 'production',
@@ -61,29 +61,11 @@ class EnvironmentManagement {
         return `https://api.${stage}.cloudios.${account}.cloud`;
     };
 
-    private getLambdaUrlV1 = (service: LambdaAPIService) => {
+    getLambdaUrl = (service: LambdaAPIService) => {
         const stage = this.getStage();
         const account = stage === StageTypes.DEVELOPMENT ? 'flowfact-dev' : 'flowfact-prod';
 
-        return `https://${service.name}.${stage}.sf.${account}.cloud`;
-    };
-
-    private getLambdaUrlV2 = (service: LambdaAPIService) => {
-        return `${this.getBaseUrl(false)}/${service.name}`;
-    }
-
-    getLambdaUrl = (service: LambdaAPIService) => {
-        if (service.url) {
-            return service.url;
-        }
-        switch (service.apiVersion) {
-            case LambdaAPIVersion.V2:
-                return this.getLambdaUrlV2(service);
-            case LambdaAPIVersion.V1:
-                return this.getLambdaUrlV1(service);
-            default:
-                throw Error('Unhandled Lambda API version')
-        }
+        return service.url ?? `https://${service.name}.${stage}.sf.${account}.cloud`;
     };
 
     getS3BucketUrl = (service: S3APIService) => {


### PR DESCRIPTION
…at works with our lambda

## Summary
Change the is24EstateStatisticsLambdaService from LambdaAPIService to APIService, because the is24-estate-statistics-lambda path matches the default format instead of the "lambda" one.

-   ...
-   ...
-   ...

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings (ESLint)

## Links

-   Jira: https://jira.scout24.com/browse/CXGFF-394

Thanks so much for your PR, your contribution is appreciated! ❤️
