### PR TITLE
feat CXGFF-393 - contactRequestAmount doesn't use portalId

### DIFF
--- a/src/service/IS24EstateStatisticsService/IS24StatisticsController.ts
+++ b/src/service/IS24EstateStatisticsService/IS24StatisticsController.ts
@@ -30,13 +30,11 @@ export default class IS24StatisticsController extends APIClient {
     /**
      * Fetches IS24 contact request amount value for given estate
      * @param is24EstateIds
-     * @param portalId
      */
-    async fetchContactRequestsAmount(is24EstateIds: string[], portalId: string) {
+    async fetchContactRequestsAmount(is24EstateIds: string[]) {
         return this.arrayValidator.validateArray(is24EstateIds)
             || await this.invokeApiWithErrorHandling<ContactRequestResponse>('/contactRequestsAmount', 'GET', {}, {
                 queryParams: {
-                    portalId,
                     scoutIds: is24EstateIds.join(',')
                 }
             });


### PR DESCRIPTION
## Summary

Remove portalId parameter from contactRequestsAmount endpoint - the backend uses OAUTH2, so PortalId is not needed here.

-   ...
-   ...
-   ...

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings (ESLint)

## Links

-   Jira:

Thanks so much for your PR, your contribution is appreciated! ❤️
